### PR TITLE
Fix a bug in the regex in build_flags_changer.rb

### DIFF
--- a/lib/injection/build_flags_changer.rb
+++ b/lib/injection/build_flags_changer.rb
@@ -306,7 +306,7 @@ module XcodeArchiveCache
         is_string = build_settings.is_a?(String)
         build_settings = build_settings.split(" ") if is_string
         full_value = get_full_flag_value(flag_name, new_value)
-        old_value_regexps = possible_old_values.map { |value| Regexp.new("#{value}\"*$") }
+        old_value_regexps = possible_old_values.map { |value| Regexp.new("/#{value}\"*$") }
 
         updated_settings = build_settings
                             .map { |line| line.split(" ") }


### PR DESCRIPTION
In our case we have two libraries where one is a suffix of the other
(Sentry vs RNSentry). The bug in the regex caused an erroneous match of
RNSentry when it tried to match Sentry, and replaced the wrong
LIBRARY_SEARCH_PATHS entry.